### PR TITLE
Don't install sbin in cooking build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,9 +399,6 @@ if (Hiactor_INSTALL)
       DIRECTORY ${Hiactor_COOKING_INSTALL_DIR}/bin/
       DESTINATION ${CMAKE_INSTALL_BINDIR})
     install (
-      DIRECTORY ${Hiactor_COOKING_INSTALL_DIR}/sbin/
-      DESTINATION ${CMAKE_INSTALL_SBINDIR})
-    install (
       DIRECTORY ${Hiactor_COOKING_INSTALL_DIR}/lib/
       DESTINATION ${CMAKE_INSTALL_LIBDIR})
     install (


### PR DESCRIPTION
Fixes an error in cooking build.

```
CMake Error at cmake_install.cmake:54 (file):
  file INSTALL cannot find "/tmp/hiactor/build/cooking_install/sbin": No such
  file or directory.
```